### PR TITLE
Fix bug, when commonInit never calls.

### DIFF
--- a/TWRCharts/TWRChartView.m
+++ b/TWRCharts/TWRChartView.m
@@ -32,6 +32,17 @@
     return self;
 }
 
+- (id)init
+{
+    self = [super init];
+    if ( self )
+    {
+        [self commonInit];
+    }
+
+    return self;
+}
+
 - (void)commonInit {
     // Setting self as the delegate
     self.delegate = self;

--- a/TWRCharts/TWRChartView.m
+++ b/TWRCharts/TWRChartView.m
@@ -32,6 +32,18 @@
     return self;
 }
 
+- (id)initWithCoder:(NSCoder *)coder
+{
+    self = [super initWithCoder:coder];
+    if ( self )
+    {
+        [self commonInit];
+    }
+
+    return self;
+}
+
+
 - (id)init
 {
     self = [super init];


### PR DESCRIPTION
Fix bug, when commonInit never calls.
Add call commonInit from init function. (It's needed, when you link TWRChartView with storyboard and init calls automatically)
